### PR TITLE
Peergos dependency as a sub-module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "peergos"]
+	path = peergos
+	url = https://github.com/Peergos/Peergos

--- a/build.xml
+++ b/build.xml
@@ -3,12 +3,24 @@
     Building Peergos and the web UI
   </description>
 
-  <property name="server_src" location="../Peergos"/>
+  <property name="peergos_project_root" location="peergos"/>
   <property name="server" location="server"/>
   <property name="ui_src" location="src"/>
   <property name="ui" location="dist"/>
   <property name="assets" location="assets"/>
   <property name="vendor" location="vendor"/>
+
+
+  <target name="peergos_submodule" description="sync. peergos dependency">
+          <exec executable="git" dir="." failonerror="true">
+                  <arg value="submodule"/>
+                  <arg value="init"/>
+          </exec>
+          <exec executable="git" dir="." failonerror="true">
+                  <arg value="submodule"/>
+                  <arg value="update"/>
+          </exec>
+  </target>
 
   <target name="init">
     <mkdir dir="${ui}/css/"/>
@@ -114,10 +126,10 @@
   <!-- server building and running -->
 
   <target name="compile_server" depends="init" description="compile and build the server">
-    <exec executable="ant" dir="${server_src}" failonerror="true">
+    <exec executable="ant" dir="${peergos_project_root}" failonerror="true">
       <arg value="dist"/>
     </exec>
-    <exec executable="ant" dir="${server_src}" failonerror="true">
+    <exec executable="ant" dir="${peergos_project_root}" failonerror="true">
       <arg value="gwtc"/>
     </exec>
   </target>
@@ -125,13 +137,13 @@
   <target name="update_server" depends="compile_server" description="regenerate the server">
     <mkdir dir="${server}/lib"/>
     <copy todir="${server}/lib">
-      <fileset dir="${server_src}/lib"/>
+      <fileset dir="${peergos_project_root}/lib"/>
     </copy>
     <copy todir="${server}">
-      <fileset file="${server_src}/PeergosServer.jar"/>
+      <fileset file="${peergos_project_root}/PeergosServer.jar"/>
     </copy>
     <copy todir="${ui}/js">
-      <fileset file="${server_src}/war/peergoslib/*cache.js"/>
+      <fileset file="${peergos_project_root}/war/peergoslib/*cache.js"/>
     </copy>
   </target>
 
@@ -147,7 +159,7 @@
     </exec>
   </target> 
 
-  <target name="update_and_run" depends="update_server,run">
+  <target name="update_and_run" depends="peergos_submodule,update_server,run">
   </target>
 
   <target name="test" depends="">


### PR DESCRIPTION
Added Peergos repo as a submodule and updated the ant targets to use the submodule rather than expecting Peergos repo to be checked out in a sibling directory  to the project root.