### PR TITLE
Wrap long filenames

### DIFF
--- a/src/peergos.css
+++ b/src/peergos.css
@@ -363,3 +363,5 @@ table {
 .btn-shared-with {
   padding: 0px 0px 0px 0px;
 }
+
+h3 {word-wrap:break-word; white-space:normal;}


### PR DESCRIPTION
When uploading a file, the progress bar dialog will become stupidly big if the filename is too long. This fixes that.