### PR TITLE
detect safari in supportsStreaming

### DIFF
--- a/src/components/downloader/index.js
+++ b/src/components/downloader/index.js
@@ -13,7 +13,10 @@ module.exports = {
 	
 	supportsStreaming: function() {
         try {
-		    return 'serviceWorker' in navigator && !!new ReadableStream() && !!new WritableStream()
+            //see https://github.com/jimmywarting/StreamSaver.js/issues/69
+            //safari is getting writable streams, but unable to use them due to issues
+            let safari = /constructor/i.test(window.HTMLElement) || !!window.safari || !!window.WebKitPoint
+		    return !safari && 'serviceWorker' in navigator && !!new ReadableStream() && !!new WritableStream()
         } catch(err) {
 		    return false;
         }


### PR DESCRIPTION
Safari now has writable streams in Safari Tech Preview (based on latest webkit)
Unfortunately there is an issue using service workers to download content.
For now it is necessary to detect safari and return false from supportsStreaming()
