### PR TITLE
clicking on current directory part will result in directory refreshing

### DIFF
--- a/src/components/filesystem/index.js
+++ b/src/components/filesystem/index.js
@@ -560,6 +560,8 @@ module.exports = {
 
             if (newLevel < this.path.length) {
                 this.changePath(path);
+            } else if (newLevel == this.path.length) {
+                this.currentDirChanged();
             }
         },
 


### PR DESCRIPTION
This is useful when a user has shared a new item in a shared directory and the recipient navigated to the directory
 before the new item was added.
This may also be useful in the case of a CAS exception.