### PR TITLE
optimise social feed init

### DIFF
--- a/src/components/filesystem/index.js
+++ b/src/components/filesystem/index.js
@@ -1330,12 +1330,14 @@ module.exports = {
             }
 	    this.toggleNav();
             this.showSpinner = true;
+            this.spinnerMessage = "Building your social feed. This could take a minute...";
             const ctx = this.getContext()
             ctx.getSocialFeed().thenCompose(function(socialFeed) {
 		return socialFeed.update().thenApply(function(updated) {
                     that.socialFeed = updated;
                     that.showTimeline = true;
                     that.showSpinner = false;
+                    that.spinnerMessage = "";
 		    that.updateHistory("timeline", that.getPath(), "");
 		});
             }).exceptionally(function(throwable) {

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -946,7 +946,7 @@ module.exports = {
 	    init: function() {
             var that = this;
             that.showSpinner = true;
-            this.pageEndIndex = Math.max(0, this.socialFeed.getLastSeenIndex() -2); //-2 is an optimisation
+            this.pageEndIndex = this.socialFeed.getLastSeenIndex();
             this.retrieveUnSeen(this.pageEndIndex, 100, []).thenApply(function(unseenItems) {
                 let items = that.filterSharedItems(unseenItems.reverse());
                 if (items.length > 0) {

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -946,7 +946,7 @@ module.exports = {
 	    init: function() {
             var that = this;
             that.showSpinner = true;
-            this.pageEndIndex = this.socialFeed.getLastSeenIndex();
+            this.pageEndIndex = Math.max(0, this.socialFeed.getLastSeenIndex() -2); //-2 is an optimisation
             this.retrieveUnSeen(this.pageEndIndex, 100, []).thenApply(function(unseenItems) {
                 let items = that.filterSharedItems(unseenItems.reverse());
                 if (items.length > 0) {
@@ -961,7 +961,7 @@ module.exports = {
                         that.pageEndIndex = startIndex;
                         items = items.concat(that.filterSharedItems(additionalItems.reverse()));
                         var numberOfEntries = items.length;
-                        if (numberOfEntries == 0) {
+                        if (numberOfEntries == 0 && startIndex > 0) {
                             that.requestMoreResults();
                         } else {
                             that.buildInitialTimeline(items);

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -909,7 +909,7 @@ module.exports = {
             this.socialFeed.update().thenApply(function(updated) {
                 that.socialFeed = updated;
                 that.updateSocialFeedInstance(updated);
-                that.retrieveUnSeen(lastSeenIndex, that.pageSize, []).thenApply(function(unseenItems) {
+                that.retrieveUnSeen(lastSeenIndex, 100, []).thenApply(function(unseenItems) {
                     that.retrieveResults(that.pageEndIndex, lastSeenIndex, []).thenApply(function(additionalItems) {
                         let items = that.filterSharedItems(unseenItems.reverse().concat(additionalItems.reverse()));
                         var numberOfEntries = items.length;
@@ -947,7 +947,7 @@ module.exports = {
             var that = this;
             that.showSpinner = true;
             this.pageEndIndex = this.socialFeed.getLastSeenIndex();
-            this.retrieveUnSeen(this.pageEndIndex, this.pageSize, []).thenApply(function(unseenItems) {
+            this.retrieveUnSeen(this.pageEndIndex, 100, []).thenApply(function(unseenItems) {
                 let items = that.filterSharedItems(unseenItems.reverse());
                 if (items.length > 0) {
                     that.buildInitialTimeline(items).thenApply(function(addedItems) {


### PR DESCRIPTION
If there are unseen items, short circuit process to only display the new items. 
Previous items are retrieved via standard 'request' more button if desired.