### PR TITLE
fix logout on user settings menu

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,7 +3,9 @@
 const helpers = require("../mixins/storage/index.js");
 function shallow(val) {
     // tag a value so vue will only shallow watch it
-    val._isVue = true;
+    if (val != null) {
+        val._isVue = true;
+    }
     return val;
 }
 module.exports = new Vuex.Store({


### PR DESCRIPTION
call to this.$store.commit("SET_CONTEXT", null) was failing as shallow() was expecting a non-null parameter value