### PR TITLE
revert to async JSForkJoinPool

### DIFF
--- a/vendor/priors/gwt.js
+++ b/vendor/priors/gwt.js
@@ -459,7 +459,7 @@ var scryptJS = {
 var ForkJoinJS = {
     JSForkJoinPool: function() {
 	this.execute = function(task) {
-            task.run()
+            setTimeout(() => task.run(), 0)
 	}
     }
 }


### PR DESCRIPTION
This is no longer needed to be inline because CompletableFuture.complete no longer uses it.