### PR TITLE
fix styling of buttons on share screen

### DIFF
--- a/src/components/drive/DriveShare.vue
+++ b/src/components/drive/DriveShare.vue
@@ -82,7 +82,16 @@
 							<p>Read and Write Access:</p>
 							<div v-if="this.files[0].getOwnerName() == this.context.username">
 								<div v-for="user in filterEditSharedWithUsers()">
-									<input type="checkbox" v-bind:id="user" v-bind:value="user" v-model="unsharedEditAccessNames">&nbsp;<span>{{ getUserOrGroupName(user) }}</span>
+									<label class="checkbox__group">
+										{{ getUserOrGroupName(user) }}
+										<input
+											type="checkbox"
+											:id="user"
+											:value="user"
+											v-model="unsharedEditAccessNames"
+										/>
+										<span class="checkmark"></span>
+									</label>
 								</div>
 								<button :disabled="this.unsharedEditAccessNames.length == 0" class="btn btn-success" v-on:click="unshare('Edit')">Revoke</button>
 							</div>
@@ -112,14 +121,7 @@
 										<span class="checkmark"></span>
 									</label>
 								</div>
-								<AppButton
-									:disabled="this.unsharedReadAccessNames.length == 0"
-									size="small"
-									outline
-									@click.native="unshare('Read')"
-								>
-									Revoke
-								</AppButton>
+                                <button :disabled="this.unsharedReadAccessNames.length == 0" class="btn btn-success" v-on:click="unshare('Read')">Revoke</button>
 							</div>
 							<div v-if="this.files[0].getOwnerName() != this.context.username">
 								<div v-for="user in filterReadSharedWithUsers()">


### PR DESCRIPTION
On the share screen there is inconsistency in the styling.
The radio buttons are not style the same
The revoke buttons are not styled the same
This PR rectifies this.
After screenshot
![Screen Shot 2022-05-03 at 9 17 36 am](https://user-images.githubusercontent.com/5311499/166423007-a1724d52-d89c-4b0e-97da-4efbc2f8d350.png)

