### PR TITLE
chrome fixes

### DIFF
--- a/assets/apps/sandbox/sandbox.html
+++ b/assets/apps/sandbox/sandbox.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <div>
-    <iframe id="appSandboxId" frameBorder="0" scrolling="yes"></iframe>
+    <iframe id="appSandboxId" frameBorder="0" sandbox="allow-same-origin allow-scripts allow-forms allow-modals" scrolling="yes"></iframe>
 </div>
 <script src="sandbox.js"></script>
 </body>


### PR DESCRIPTION
1 seems to have resolved issue with opfs and chrome. opfs is now enabled for firefox and chrome. no limit on the number of cached blocks.

2 while testing ck-editor app i noticed a discrepency between behaviour between localhost and deployed version. The new print preview functionality works over localhost, but was failing on test. Adding the sandbox attribute to the sandbox iframe was required to make it work on test.