### PR TITLE
Add packaging into container image

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,47 @@
+name: Create and publish a Container image
+
+on: [push]
+# TODO: revert to building on `main` branch only
+#on:
+#  push:
+#    branches: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          file: Containerfile
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,6 +1,7 @@
 name: Create and publish a Container image
 
 on: [push]
+
 # TODO: revert to building on `main` branch only
 #on:
 #  push:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,6 +1,7 @@
 name: Create and publish a Container image
 
-on: [push]
+on:
+  push
 
 # TODO: revert to building on `main` branch only 
 #on:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,7 +2,7 @@ name: Create and publish a Container image
 
 on: [push]
 
-# TODO: revert to building on `main` branch only
+# TODO: revert to building on `main` branch only 
 #on:
 #  push:
 #    branches: ['main']

--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,11 @@ RUN ant dist
 
 FROM eclipse-temurin:17-jre
 
+LABEL org.opencontainers.image.title="Peergos"
+LABEL org.opencontainers.image.description="Peergos is a peer-to-peer encrypted global filesystem with fine-grained access control designed to be resistant to surveillance of data content or friendship graphs"
+LABEL org.opencontainers.image.source="https://github.com/Peergos/web-ui"
+LABEL org.opencontainers.image.licenses="GPLv3"
+
 ENV PEERGOS_PATH=/opt/peergos/data
 
 WORKDIR /opt/peergos

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,21 @@
+FROM eclipse-temurin:17-jdk as build
+
+RUN apt-get update && apt-get install --assume-yes ant git
+
+COPY . /opt/peergos
+WORKDIR /opt/peergos
+
+RUN ant dist
+
+
+FROM eclipse-temurin:17-jre
+
+ENV PEERGOS_PATH=/opt/peergos/data
+
+WORKDIR /opt/peergos
+RUN mkdir -p /opt/peergos/data
+COPY --from=build /opt/peergos/server /opt/peergos/server
+
+ENTRYPOINT ["java", "-jar", "/opt/peergos/server/Peergos.jar"]
+
+EXPOSE 4001 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+Containerfile

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ Apache Ant(TM) version 1.10.8 compiled on May 10 2020
 
 The output will be server/Peergos.jar
 
+### Container Image (Docker)
+
+Package Peergos into a container image with: 
+
+```bash
+docker build --file Containerfile --tag peergos:dev .
+```
+
+Then start Peergos inside the container with: 
+```bash
+docker run --volume $(PEERGOS_PATH):/opt/peergos/data peergos:dev daemon -log-to-console true
+```
+
+
 ## Development
 
 ### Server


### PR DESCRIPTION
This adds a first `Containerfile` that can be used to package Peergos into a container image. 

Notes: 

- a multi-stage build is used so that the final container image only contains the JRE + the app (no unnecessary JDK stuff)
- a `Dockerfile` is added as a symbolic link to the vendor-agnostic `Containerfile`, for convenience
- here's a link about "Containerfile vs. Dockerfile" - https://github.com/containers/buildah/discussions/3170
- this PR is still WIP - we should probably still add some github action that builds the container image, runs some smoke test against it and publishes to a container image registry. 