### PR TITLE
Fix too large x for app grid menu when sidebar is open

### DIFF
--- a/src/components/app-grid/AppGrid.vue
+++ b/src/components/app-grid/AppGrid.vue
@@ -59,6 +59,8 @@ module.exports = {
                 posx = e.clientX - 60;
                 posy = e.clientY - 100;
             }
+            if (e.layerX) // This fixes too large X when side bar is open
+                posx = e.layerX;
             return {
                 x: posx,
                 y: posy


### PR DESCRIPTION
Tested on chromium and firefox desktop