### PR TITLE
resize confirm modal

### DIFF
--- a/assets/apps/markup-viewer/init.js
+++ b/assets/apps/markup-viewer/init.js
@@ -147,7 +147,13 @@ function addMathJax(text) {
     script.setAttribute("src", './es5/tex-chtml.js');
     document.getElementsByTagName("head")[0].appendChild(script);
 }
-function updateResources(format) {
+function updateResources() {
+    let that = this;
+    setTimeout(() => {
+        that.updateResourcesInDoc();
+    }, 100);
+}
+function updateResourcesInDoc() {
         let anchors = document.getElementsByTagName("a");
         for(var i=0; i < anchors.length;i++) {
             let anchor = anchors[i];
@@ -322,7 +328,7 @@ function initialiseEditorJS(theme, jsonData) {
             data: jsonData,
             onReady: function(){
                 new DragDrop(editorJS);
-                updateResources("note");
+                updateResources();
             },
             onChange: function(api, event) {
                 //console.log('change event: ', event);

--- a/src/components/confirm/Confirm.vue
+++ b/src/components/confirm/Confirm.vue
@@ -2,7 +2,7 @@
 <transition name="modal">
 <div class="modal-mask" @click="close">
   <div style="height:30%"></div>
-  <div class="modal-container" @click.stop>
+  <div class="confirm-modal-container" @click.stop>
 
     <div class="modal-header">
       <h3 id="confirm-header-id">{{confirm_message}}</h3>
@@ -48,4 +48,15 @@ module.exports = {
 }
 </script>
 <style>
+.confirm-modal-container {
+    width: 40%;
+    margin: 0px auto;
+    padding: 20px 30px;
+	color: var(--color);
+    background-color: var(--bg);
+    border-radius: 2px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
+    transition: all .3s ease;
+    min-width: 300px;
+}
 </style>

--- a/src/views/Launcher.vue
+++ b/src/views/Launcher.vue
@@ -856,12 +856,20 @@ module.exports = {
             });
 
         },
+        uuid: function() {
+          return '-' + ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+            (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+          );
+        },
         showMessage: function(isError, title, body) {
             let bodyContents = body == null ? '' : ' ' + body;
             if (isError) {
                 this.$toast.error(title + bodyContents, {timeout:false});
             } else {
-                this.$toast(title + bodyContents)
+                let id = this.uuid();
+                this.$toast(title + bodyContents, {id: id});
+                let that = this;
+                setTimeout(() => that.$toast.dismiss(id), 3000);
             }
         },
         showErrorMessage(errMsg) {


### PR DESCRIPTION
confirm modal now does not take up the whole width of the screen
2 addtional small fixes
- when a new file is created from clicking an app on the launcher page, the toast to indicate a new file has been created now is dismissed after a few seconds
- the markup viewer now waits a small amount of time before updating the link/image resources in the file.