### PR TITLE
introduce method to ease installation of recommended app for file on Drive and Newsfeed

### DIFF
--- a/assets/apps/sandbox/sandbox.js
+++ b/assets/apps/sandbox/sandbox.js
@@ -74,7 +74,8 @@ function load(appName, appPath, allowBrowsing, theme, chatId, username, props) {
             if (props.isPathWritable == true) {
                 path = path + '&isPathWritable=' + props.isPathWritable;
             }
-            let src = allowBrowsing ? appPath.substring(1) : "index.html" + path;
+            let anchor = props.htmlAnchor.length > 0 ? '#' + props.htmlAnchor : "";
+            let src = allowBrowsing ? appPath.substring(1) + anchor : "index.html" + path;
             iframe.src= src;
             iframe.contentWindow.focus();
             that.startPing(url + "/ping");

--- a/src/components/picker/NewFilePicker.vue
+++ b/src/components/picker/NewFilePicker.vue
@@ -124,7 +124,7 @@ module.exports = {
 		getPrompt() {
 		    var filename = this.prompt_result;
 		    if (filename.length > 0 && this.folder_result.length > 0) {
-                if (!filename.endsWith(this.pickerFileExtension)) {
+                if (!filename.endsWith("." + this.pickerFileExtension)) {
                     filename = filename + '.' + this.pickerFileExtension;
                 }
                 this.consumer_func(filename, this.folder_result);

--- a/src/components/sandbox/AppSandbox.vue
+++ b/src/components/sandbox/AppSandbox.vue
@@ -236,7 +236,7 @@ module.exports = {
             return this.socialData.friends;
         }
     },
-    props: ['sandboxAppName', 'currentFile', 'currentPath', 'currentProps', 'sandboxAppChatId'],
+    props: ['sandboxAppName', 'currentFile', 'currentPath', 'currentProps', 'sandboxAppChatId', 'htmlAnchor'],
     created: function() {
         let that = this;
         this.messenger = new peergos.shared.messaging.Messenger(this.context);
@@ -523,7 +523,8 @@ module.exports = {
                 let href = window.location.href;
                 let appDevMode = href.includes("?local-app-dev=true");
                 let allowUnsafeEvalInCSP = that.permissionsMap.get(that.PERMISSION_CSP_UNSAFE_EVAL) != null;
-                let props = { appDevMode: appDevMode, allowUnsafeEvalInCSP: allowUnsafeEvalInCSP, isPathWritable: that.isPathWritable()};
+                let props = { appDevMode: appDevMode, allowUnsafeEvalInCSP: allowUnsafeEvalInCSP, isPathWritable: that.isPathWritable(),
+                    htmlAnchor: that.htmlAnchor == null ? "" : that.htmlAnchor};
                 let func = function() {
                     that.postMessage({type: 'init', appName: that.currentAppName, appPath: that.appPath,
                     allowBrowsing: that.browserMode, theme: theme, chatId: that.currentChatId,

--- a/src/i18n/en-GB.js
+++ b/src/i18n/en-GB.js
@@ -110,6 +110,7 @@ module.exports = {
     "DRIVE.DELETE.ERROR":"Error deleting files",
     "DRIVE.DELETE.CONFIRM":"Are you sure you want to delete $COUNT items?",
     "DRIVE.DELETE.FILE.ERROR":"Error deleting file: $NAME: $MESSAGE",
+    "DRIVE.INSTALL_DEDICATED_APP":"There is no app installed for this kind of file, please install an app to open",
     "APPNAV.LAUNCHER":"Launcher",
     "APPNAV.DRIVE":"Drive",
     "APPNAV.NEWSFEED":"Newsfeed",

--- a/src/mixins/router/index.js
+++ b/src/mixins/router/index.js
@@ -109,6 +109,31 @@ module.exports = {
            return [];
        }
     },
+    getRecommendedViewer(file) {
+        let filename = file.getName();
+        if (file.isDirectory()) {
+            return null;
+        }
+        try {
+            let extension = filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
+            if (extension == "docx" || extension == "odt") {
+                return "doc-viewer";
+            } else if (extension == "sheet" || extension == "xlsx" || extension == "ods") {
+                return "luckysheet";
+            } else if (extension == "tldr") {
+                return "tldraw";
+            } else if (extension == "drawio") {
+                return "drawio";
+            } else if (extension == "todo") {
+                return "tasks";
+            } else if (extension == "epub") {
+                return "ebookreader";
+            }
+        } catch (ex) {
+            return null;
+        }
+        return null;
+    },
     getInbuiltApps(file) {
         let filename = file.getName();
         let mimeType = file.getFileProperties().mimeType;

--- a/src/views/Drive.vue
+++ b/src/views/Drive.vue
@@ -2732,6 +2732,7 @@ module.exports = {
             let path = "/peergos/recommended-apps/";
             this.context.getByPath(path + "index.html").thenApply(function(fileOpt){
                 if (fileOpt.ref != null && fileOpt.get().getFileProperties().sizeLow() > 20) {
+                    that.$toast(that.translate("DRIVE.INSTALL_DEDICATED_APP"), {timeout:false});
                     that.showAppSandbox = true;
                     that.sandboxAppName = '$$app-gallery$$';
                     that.currentFile = fileOpt.get();

--- a/src/views/Launcher.vue
+++ b/src/views/Launcher.vue
@@ -46,7 +46,8 @@
                 v-on:hide-app-sandbox="closeAppSandbox"
                 :sandboxAppName="sandboxAppName"
                 :currentFile="currentFile"
-                :currentPath="currentPath">
+                :currentPath="currentPath"
+                :htmlAnchor="htmlAnchor">
             </AppSandbox>
             <Confirm
                     v-if="showConfirm"
@@ -273,6 +274,7 @@ module.exports = {
             pickerFilters: null,
             pickerShowThumbnail: false,
             filePickerBaseFolder: "",
+            htmlAnchor: "",
         }
     },
     props: [],

--- a/src/views/NewsFeed.vue
+++ b/src/views/NewsFeed.vue
@@ -1153,6 +1153,7 @@ module.exports = {
             let path = "/peergos/recommended-apps/";
             this.context.getByPath(path + "index.html").thenApply(function(fileOpt){
                 if (fileOpt.ref != null && fileOpt.get().getFileProperties().sizeLow() > 20) {
+                    that.$toast(that.translate("DRIVE.INSTALL_DEDICATED_APP"), {timeout:false});
                     that.sandboxAppName = '$$app-gallery$$';
                     that.currentFile = fileOpt.get();
                     that.currentPath = path;


### PR DESCRIPTION
Now if a user double clicks on a file for which their is a recommended app:
The recomended app page is dispayed and the app in question is highlighted
- if app is subsequently installed, then it will be used to open the file
- if app is not installed, the default app ie 'hex' will be used.

anchor tags have been added to index.html for recommended-apps