### PR TITLE
add cross-origin-isolated to sandbox iframe

### DIFF
--- a/src/components/sandbox/AppSandbox.vue
+++ b/src/components/sandbox/AppSandbox.vue
@@ -621,6 +621,7 @@ module.exports = {
             iframe.style.height = '100%';
             iframe.frameBorder="0";
             iframe.scrolling="no";
+            iframe.allow="cross-origin-isolated";
             iframeContainer.appendChild(iframe);
             Vue.nextTick(function() {
                 iframe.src = that.frameUrl();


### PR DESCRIPTION
Using hint from:
https://issues.chromium.org/issues/346852676

And text from:
https://web.dev/articles/cross-origin-isolation-guide

Have added allow attribute to iframe and set it to ' cross-origin-isolated '

Have tested in chrome and inner most iframe now has window.crossOriginIsolated = true