### PR TITLE
support template apps

### DIFF
--- a/src/components/Group.vue
+++ b/src/components/Group.vue
@@ -14,7 +14,7 @@
         </Prompt>
         <div class="modal-header">
             <span>
-                <h4 style="text-align: center;" @click="changeGroupTitle()">{{ displayedTitle }}&nbsp;&nbsp;<i v-if="isAdmin" @click="changeGroupTitle()" class="fa fa-edit" aria-hidden="true"></i></h4>
+                <h4 style="text-align: center;" @click="changeGroupTitle()">{{ displayedTitle }}&nbsp;&nbsp;<i v-if="isAdmin && allowTitleChange" @click="changeGroupTitle()" class="fa fa-edit" aria-hidden="true"></i></h4>
             </span>
         </div>
 
@@ -124,14 +124,15 @@ module.exports = {
             prompt_consumer_func: () => {},
             displayedTitle: "",
             updateLabel: "Apply Changes",
-            addLabel: "Invite to Chat",
+            addLabel: "Invite",
             genericLabel: "chat",
             isAdmin: false,
-            memberAccess: "Member"
+            memberAccess: "Member",
+            allowTitleChange: true,
         }
     },
     props: ['existingGroups', 'groupId', 'groupTitle', 'existingGroupMembers', 'friendNames'
-        , 'updatedGroupMembership', 'existingAdmins'],
+        , 'updatedGroupMembership', 'existingAdmins', 'isTemplateApp'],
     computed: {
         ...Vuex.mapState([
             'context',
@@ -143,6 +144,9 @@ module.exports = {
             this.updateLabel = "Create";
         }
         this.isAdmin = this.existingAdmins.findIndex(v => v === this.context.username) > -1;
+        if (this.isTemplateApp) {
+            this.allowTitleChange = false;
+        }
     },
     methods: {
         updateGroupMembership: function () {
@@ -164,7 +168,7 @@ module.exports = {
             }
         },
         changeGroupTitle: function () {
-            if (!this.isAdmin) {
+            if (!this.isAdmin || !this.allowTitleChange) {
                 return;
             }
             let that = this;

--- a/src/components/prompt/AppTemplatePrompt.vue
+++ b/src/components/prompt/AppTemplatePrompt.vue
@@ -1,0 +1,206 @@
+<template>
+	<transition name="modal" appear>
+		<div class="app-template-prompt app-modal__overlay" @click="closePrompt()">
+
+			<div class="app-template-prompt__container" @click.stop>
+				<header class="template-prompt__header">
+					<AppButton class="close" icon="close" @click.native="closePrompt()"/>
+					<h3>{{message}}</h3>
+				</header>
+				<div class="modal-body" style="padding: 15px;">
+                        <div class="flex-thumbnail-container">
+                            <div style="padding:20px;">
+		                        <img id="profile-image" alt="Profile image" v-if="hasAppIcon()" style="width:128px; height:128px" v-bind:src="getAppIcon()"/>
+	                        </div>
+                            <div class="flex-image-button-container">
+                                <div class="flex-container">
+		                            <button class="btn btn-success flex-grow" @click="triggerUpload">Set Icon</button>
+		                            <input type="file" id="uploadImageInput" @change="uploadImageFile" style="display:none;" accept="image/*" />
+		                        </div>
+                            </div>
+                        </div>
+                </div>
+				<div v-if="maxLength > 0" class="template-prompt__body" style="margin: 20px;">
+					<input
+						v-if="placeholder"
+						id="prompt-input"
+						ref="prompt"
+						v-model="prompt_result"
+						type="text"
+						:placeholder="placeholder"
+						:maxlength="maxLength"
+						@keyup.enter="getPrompt(this.prompt_result)"
+						autofocus
+					>
+					</input>
+				</div>
+				<footer class="template-prompt__footer">
+					<AppButton outline @click.native="closePrompt()">
+						{{ translate("PROMPT.CANCEL") }}
+					</AppButton>
+
+					<AppButton
+						id='prompt-button-id'
+						type="primary"
+						accent
+						@click.native="getPrompt(this.prompt_result)"
+					>
+					{{action}}
+					</AppButton>
+				</footer>
+			</div>
+		</div>
+	</transition>
+</template>
+
+<script>
+const AppButton = require("../AppButton.vue");
+const i18n = require("../../i18n/index.js");
+
+module.exports = {
+    components: {
+        AppButton,
+    },
+    mixins:[i18n],
+	data() {
+		return {
+			prompt_result: '',
+			base64Image:'',
+		}
+	},
+	props: {
+		message: {
+			type: String,
+			default: ''
+		},
+		placeholder: {
+			type: String,
+			default: null
+		},
+		value:{
+			type: String,
+			default: ''
+		},
+		max_input_size:{
+			type: Number,
+			default: 255
+		},
+		consumer_func: {
+			type: Function
+		},
+		action:{
+			type: String,
+		},
+        appIconBase64Image:{
+            type: String,
+        },
+	},
+	computed: {
+		maxLength() {
+		    if (this.max_input_size == -1) {
+		        return -1;
+		    }
+			return (this.max_input_size == '') ? 32 : this.max_input_size;
+		}
+	},
+
+	mounted() {
+		this.prompt_result = this.value;
+        this.base64Image = this.appIconBase64Image;
+		if(this.placeholder !== null && this.maxLength > 0){
+			this.$refs.prompt.focus()
+		}
+	},
+
+	methods: {
+		closePrompt() {
+			this.consumer_func(null, null);
+			this.$emit("hide-prompt");
+		},
+
+		getPrompt() {
+			this.consumer_func(this.prompt_result, this.base64Image);
+			this.$emit("hide-prompt");
+		},
+        getAppIcon: function() {
+            return this.base64Image;
+        },
+        hasAppIcon: function() {
+            return this.base64Image.length > 0;
+        },
+        triggerUpload: function() {
+            document.getElementById('uploadImageInput').click()
+        },
+        uploadImageFile: function(evt) {
+            let files = evt.target.files || evt.dataTransfer.files;
+            let file = files[0];
+            let that = this;
+            let filereader = new FileReader();
+            filereader.file_name = file.name;
+            let thumbnailWidth = 64;
+            let thumbnailHeight = 64;
+            filereader.onload = function(){
+                let canvas = document.createElement("canvas");
+                canvas.width = thumbnailWidth;
+                canvas.height = thumbnailHeight;
+                let context = canvas.getContext("2d");
+                let image = new Image();
+                image.onload = function() {
+                    try {
+                        context.drawImage(image, 0, 0, thumbnailWidth, thumbnailHeight);
+                    } catch (ex) {
+                        console.log("Unable to create icon. Maybe blocked by browser addon?");
+                    }
+                    that.base64Image = canvas.toDataURL();
+                };
+                image.onerror = function() {
+                    that.showMessage(true, that.translate("PROFILE.ERROR.IMAGE"));
+                };
+                image.src = this.result;
+            };
+            filereader.readAsDataURL(file);
+        },
+	}
+}
+
+</script>
+
+<style>
+.app-template-prompt.app-modal__overlay{
+	display:flex;
+	align-items: center;
+	justify-content: center;
+}
+.app-template-prompt__container{
+	width: 400px;
+	padding: 16px;
+	border-radius: 4px;
+	color: var(--color);
+	background-color:var(--bg);
+	box-shadow: 0 6px 16px rgba(0,0,0,0.15);
+}
+.template-prompt__header h3{
+	border-top:0;
+	font-weight: var(--regular);
+}
+.template-prompt__body{
+	margin: var(--app-margin) 0;
+}
+.template-prompt__footer{
+	display: flex;
+	justify-content: flex-end;
+}
+.template-prompt__footer button{
+	margin-left: 16px;
+}
+.flex-thumbnail-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.flex-image-button-container {
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/src/components/sandbox/AppDetails.vue
+++ b/src/components/sandbox/AppDetails.vue
@@ -37,6 +37,9 @@
                     <p>
                         <span v-if="appProperties.folderAction==true" class="app-install-span">Is a Folder Action</span>
                     </p>
+                    <p>
+                        <span v-if="appProperties.template.length > 0" class="app-install-span">Multiple instances of App can be installed</span>
+                    </p>
                     <p v-if="!appHasFileAssociation && appProperties.permissions.length == 0">
                         <span class="app-install-span">Permissions:</span><span class="app-install-text">None Required</span>
                     </p>

--- a/src/components/sandbox/AppInstall.vue
+++ b/src/components/sandbox/AppInstall.vue
@@ -17,6 +17,16 @@
                     :consumer_cancel_func="confirm_consumer_cancel_func"
                     :consumer_func="confirm_consumer_func">
             </Confirm>
+            <AppPrompt
+              v-if="showPrompt"
+              @hide-prompt="closePrompt()"
+              :message="prompt_message"
+              :placeholder="prompt_placeholder"
+              :max_input_size="prompt_max_input_size"
+              :value="prompt_value"
+              :consumer_func="prompt_consumer_func"
+              :action="prompt_action"
+            />
             <div v-if="appProperties != null">
                 <div class="app-install-view">
                     <p>
@@ -41,6 +51,9 @@
                     </p>
                     <p>
                         <span v-if="appProperties.folderAction==true" class="app-install-span">Is a Folder Action</span>
+                    </p>
+                    <p>
+                        <span v-if="appProperties.template.length > 0" class="app-install-span">Multiple instances of App can be installed</span>
                     </p>
                     <p v-if="!appHasFileAssociation && appProperties.permissions.length == 0">
                         <span class="app-install-span">Permissions:</span><span class="app-install-text">None Required</span>
@@ -67,14 +80,17 @@
 </template>
 
 <script>
+const AppPrompt = require("../prompt/AppPrompt.vue");
 const Confirm = require("../confirm/Confirm.vue");
 const Spinner = require("../spinner/Spinner.vue");
 const mixins = require("../../mixins/mixins.js");
 const downloaderMixin = require("../../mixins/downloader/index.js");
 const sandboxMixin = require("../../mixins/sandbox/index.js");
+const i18n = require("../../i18n/index.js");
 
 module.exports = {
     components: {
+        AppPrompt,
         Confirm,
         Spinner
     },
@@ -90,10 +106,20 @@ module.exports = {
             confirm_consumer_cancel_func: () => {},
             confirm_consumer_func: () => {},
             installAppFromFolder: "",
+            isTemplateApp: false,
+            prompt_message: '',
+            prompt_placeholder: '',
+            prompt_max_input_size: 16,
+            prompt_value: '',
+            prompt_consumer_func: () => { },
+            prompt_action: 'ok',
+            showPrompt: false,
+            messenger: null,
+            templateAppSeparator: "!",
         }
     },
-    props: ['appPropsFile','installFolder', "appInstallSuccessFunc"],
-    mixins:[mixins, downloaderMixin, sandboxMixin],
+    props: ['appPropsFile','installFolder', "appInstallSuccessFunc", "templateInstanceAppName", "templateInstanceTitle", "templateInstanceChatId"],
+    mixins:[mixins, downloaderMixin, sandboxMixin, i18n],
     computed: {
         ...Vuex.mapState([
             'quotaBytes',
@@ -103,6 +129,7 @@ module.exports = {
         ]),
     },
     created: function() {
+        this.messenger = new peergos.shared.messaging.Messenger(this.context);
         this.installAppFromFolder = this.installFolder.endsWith('/')  ?
             this.installFolder.substring(0, this.installFolder.length -1) : this.installFolder;
         this.loadAppProperties();
@@ -129,6 +156,7 @@ module.exports = {
                     that.appHasFileAssociation = res.props.fileExtensions.length > 0
                         || res.props.mimeTypes.length > 0
                         || res.props.fileTypes.length > 0;
+                    that.isTemplateApp = res.props.template.length > 0;
                     that.appProperties = res.props;
                 }
             });
@@ -147,14 +175,17 @@ module.exports = {
             if (this.appProperties == null) {
                 return;
             }
-            let appName = this.appProperties.name;
             let displayName = this.appProperties.displayName;
             let newVersion = this.appProperties.version;
             let that = this;
             this.showSpinner = true;
-            this.context.getByPath("/" + this.context.username + "/.apps/" + appName).thenApply(appOpt => {
+            let appName = this.appProperties.name;
+            let actualAppName = this.isTemplateApp
+                && this.templateInstanceAppName != null
+                && this.templateInstanceAppName.length > 0 ? this.templateInstanceAppName : appName;
+            this.context.getByPath("/" + this.context.username + "/.apps/" + actualAppName).thenApply(appOpt => {
                 if (appOpt.ref != null) {
-                    that.readAppProperties(appName).thenApply(props => {
+                    that.readAppProperties(actualAppName).thenApply(props => {
                         if (props == null) {
                             that.installApp();
                         } else {
@@ -162,7 +193,11 @@ module.exports = {
                             that.confirmReplaceAppInstall(displayName, oldVersion, newVersion,
                                 () => {
                                     that.showConfirm = false;
-                                    that.installApp({app:props});
+                                    if (this.isTemplateApp) {
+                                        that.installTemplateApp(props);
+                                    } else {
+                                        that.installApp(props);
+                                    }
                                 },
                                 () => {
                                     that.showConfirm = false;
@@ -173,8 +208,111 @@ module.exports = {
                         }
                     });
                 } else {
-                    that.installApp();
+                    if (this.isTemplateApp) {
+                        that.installTemplateApp();
+                    } else {
+                        that.installApp();
+                    }
                 }
+            });
+        },
+        uuid() {
+          return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+            (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+          ).substring(0, 12);
+        },
+        getTemplateAppTitle(oldProperties, callback) {
+            if (oldProperties != null) {
+                callback(oldProperties.displayName);
+            } else if(this.templateInstanceTitle != null&& this.templateInstanceTitle.length > 0) {
+                callback(this.templateInstanceTitle);
+            }else {
+                let that = this;
+                this.prompt_placeholder = this.translate("NEW.TEMPLATE.APP.NAME.LABEL");
+                this.prompt_message = this.translate("NEW.TEMPLATE.APP.NAME.MESSAGE") + " " + this.appProperties.displayName;
+                this.prompt_value = '';
+                this.prompt_action = this.translate("PROMPT.OK");
+                this.prompt_consumer_func = function (prompt_result) {
+                    if (prompt_result === null)
+                        return;
+                    let title = prompt_result.trim();
+                    if (title === '')
+                        return;
+                    if (title === '.' || title === '..')
+                        return;
+                    if (title.includes("/"))
+                        return;
+                    if (!that.validateDisplayName(title)) {
+                        return;
+                    }
+                    callback(that.appProperties.displayName + " - " +title);
+                };
+                this.showPrompt = true;
+            }
+        },
+        closePrompt() {
+            this.showPrompt = false;
+        },
+        createNewTemplateApp: function(appName, displayName, chatId) {
+            let that = this;
+            let future = peergos.shared.util.Futures.incomplete();
+            if (chatId.length > 0) {
+                future.complete(chatId);
+            } else {
+                this.messenger.createAppChat(appName).thenApply(function(controller){
+                    let chatId = controller.chatUuid;
+                    that.messenger.setGroupProperty(controller, "title", displayName).thenApply(function(updatedController) {
+                        future.complete(chatId);
+                    }).exceptionally(err => {
+                        console.log('setTitle call failed: ' + err);
+                        future.complete(null);
+                    });
+                }).exceptionally(err => {
+                    console.log('Unable to create chat. error:' + err);
+                    future.complete(null);
+                });
+            }
+            return future;
+        },
+        installTemplateApp: function(oldProperties) {
+            let that = this;
+            this.getTemplateAppTitle(oldProperties, displayName => {
+                var appName = "";
+                if (oldProperties != null) {
+                    appName = oldProperties.name;
+                } else if(that.templateInstanceAppName != null&& that.templateInstanceAppName.length > 0) {
+                    appName = that.templateInstanceAppName;
+                }else {
+                    appName = that.appProperties.name + that.templateAppSeparator + that.uuid();
+                }
+                that.context.getByPath(that.installAppFromFolder).thenApply(srcDirectoryOpt => {
+                    that.calculateTotalSize(srcDirectoryOpt.ref, that.installAppFromFolder).thenApply(statistics => {
+                        let spaceAfterOperation = that.checkAvailableSpace(statistics.apparentSize);
+                        if (spaceAfterOperation < 0) {
+                            that.showError("App installation size exceeds available Space.  Please free up " + that.convertBytesToHumanReadable('' + -spaceAfterOperation) + " and try again");
+                            that.showSpinner = false;
+                        } else {
+                            that.spinnerMessage = "Installing App: " + displayName;
+                            var existingChatId = "";
+                            if (oldProperties != null) {
+                                existingChatId = oldProperties.chatId;
+                            } else if(that.templateInstanceChatId != null && that.templateInstanceChatId.length > 0) {
+                                existingChatId = that.templateInstanceChatId;
+                            }
+                            that.createNewTemplateApp(appName, displayName, existingChatId).thenApply(chatId => {
+                                if (chatId == null) {
+                                    that.showError("App installation failed");
+                                    that.showSpinner = false;
+                                } else {
+                                    peergos.shared.user.App.init(that.context, appName).thenApply(ready => {
+                                        that.gatherDataFiles(appName, srcDirectoryOpt.ref)
+                                            .thenApply(dataFiles => that.copyAppFiles(dataFiles, appName, displayName, chatId));
+                                    });
+                                }
+                            });
+                        }
+                    });
+                });
             });
         },
        installApp: function(oldProperties) {
@@ -190,34 +328,12 @@ module.exports = {
                    } else {
                        that.spinnerMessage = "Installing App: " + displayName;
                        peergos.shared.user.App.init(that.context, appName).thenApply(ready => {
-                             that.backupPropertiesFile(appName, oldProperties).thenApply(done => {
-                                 let future = that.gatherDataFiles(appName, srcDirectoryOpt.ref);
-                                 future.thenApply(dataFiles => that.copyAppFiles(dataFiles, appName, displayName));
-                             });
+                             that.gatherDataFiles(appName, srcDirectoryOpt.ref)
+                                .thenApply(dataFiles => that.copyAppFiles(dataFiles, appName, displayName));
                        });
                    }
                });
            });
-       },
-       backupPropertiesFile: function(appName, oldProperties) {
-           var future = peergos.shared.util.Futures.incomplete();
-           if (oldProperties == null) {
-                future.complete(true);
-           } else {
-               let that = this;
-               peergos.shared.user.App.init(that.context, appName).thenApply(app => {
-                    let filePath = peergos.client.PathUtils.directoryToPath(['peergos-app-previous.json']);
-                    let encoder = new TextEncoder();
-                    let uint8Array = encoder.encode(JSON.stringify(oldProperties, null, 2));
-                    let bytes = convertToByteArray(uint8Array);
-                    app.writeInternal(filePath, bytes).thenApply(done => {
-                        that.deletePropertiesFile(appName).thenApply(done => {
-                            future.complete(true);
-                        });
-                    });
-                });
-            }
-            return future;
        },
         gatherDataFiles: function(appName, appDirectory) {
             let future = peergos.shared.util.Futures.incomplete();
@@ -286,28 +402,6 @@ module.exports = {
                 }
             }
         },
-        deletePropertiesFile(appName) {
-            let that = this;
-            let future = peergos.shared.util.Futures.incomplete();
-            let folderPath = "/" + this.context.username + "/.apps/" + appName;
-            let filename = 'peergos-app.json';
-            this.context.getByPath(folderPath).thenApply(appDirOpt => {
-                if (appDirOpt.ref != null) {
-                    appDirOpt.ref.getChild(filename, that.context.crypto.hasher, that.context.network).thenApply(fileToDeleteOpt => {
-                        if (fileToDeleteOpt.ref != null) {
-                            that.removeFile(folderPath + '/' + filename, fileToDeleteOpt.ref, appDirOpt.ref).thenApply(res => {
-                                future.complete(true);
-                            });
-                        } else {
-                            future.complete(false);
-                        }
-                    });
-                }else {
-                    future.complete(false);
-                }
-            });
-            return future;
-        },
         copyAssetsFolder(appName) {
             let that = this;
             let future = peergos.shared.util.Futures.incomplete();
@@ -362,14 +456,14 @@ module.exports = {
             });
             return future;
         },
-        copyAppFiles: function(appDataFiles, app, displayName) {
+        copyAppFiles: function(appDataFiles, app, displayName, chatId) {
             let future = peergos.shared.util.Futures.incomplete();
             let that = this;
             this.deleteAssetsFolder(app).thenApply(res => {
                 that.copyAssetsFolder(app).thenApply(res2 => {
                     that.copyAllDataFiles(appDataFiles, app, displayName).thenApply(res3 => {
                         if (res3) {
-                            that.updateSourceInAppManifest(app).thenApply(function(props){
+                            that.updateAppManifest(app, displayName, chatId).thenApply(function(props){
                                 that.appProperties = props;
                                 that.showSpinner = false;
                                 that.spinnerMessage = "";
@@ -421,12 +515,21 @@ module.exports = {
             }
             return future;
         },
-        updateSourceInAppManifest: function(appName) {
+        updateAppManifest: function(appName, appDisplayName, chatId) {
             let that = this;
             let future = peergos.shared.util.Futures.incomplete();
             this.context.getByPath(this.installAppFromFolder + '/peergos-app.json').thenApply(propsFileOpt => {
                 that.readJSONFile(propsFileOpt.ref).thenApply(props => {
                     props.source = props.source.length > 0 ? props.source : that.installAppFromFolder;
+                    if (that.isTemplateApp) {
+                        props.name = appName;
+                        if (appDisplayName.length > 0) {
+                            props.displayName = appDisplayName;
+                        }
+                        if (chatId.length > 0) {
+                            props.chatId = chatId;
+                        }
+                    }
                     let encoder = new TextEncoder();
                     let uint8Array = encoder.encode(JSON.stringify(props, null, 2));
                     let bytes = convertToByteArray(uint8Array);

--- a/src/components/sandbox/AppRunner.vue
+++ b/src/components/sandbox/AppRunner.vue
@@ -61,7 +61,8 @@ module.exports = {
                     let editPermission = res.props.permissions.filter(p => p == 'EDIT_CHOSEN_FILE').length > 0;
                     let hasFileExtensions = res.props.fileExtensions.length > 0;
                     let createFile = editPermission && hasFileExtensions;
-                    if (!res.props.launchable || (res.props.launchable && createFile) || messagePermission) {
+                    let templateApp = res.props.template.length > 0;
+                    if (!res.props.launchable || (res.props.launchable && createFile) || messagePermission || templateApp) {
                         that.showError("App must be installed first!");
                         that.close();
                     } else {

--- a/src/i18n/en-GB.js
+++ b/src/i18n/en-GB.js
@@ -492,5 +492,7 @@ module.exports = {
     "DRIVE.MOVING.COMPLETE":"Completing move and refreshing folder...",
     "DRIVE.COPYING.TITLE":"Copying file(s)",
     "DRIVE.COPYING.COMPLETE":"Completing copy and refreshing folder...",
-    "SHAREDWITH.TITLE": "Shared With"
+    "SHAREDWITH.TITLE": "Shared With",
+    "NEW.TEMPLATE.APP.NAME.LABEL":"App Title",
+    "NEW.TEMPLATE.APP.NAME.MESSAGE":"Title for App:"
 }

--- a/src/mixins/downloader/index.js
+++ b/src/mixins/downloader/index.js
@@ -214,6 +214,29 @@ module.exports = {
           result.complete(false);
         })
       return result;
+    },
+    contents: function (file) {
+      var props = file.getFileProperties()
+      var that = this
+      var resultingSize = this.getFileSize(props)
+      let result = peergos.shared.util.Futures.incomplete();
+      file.getBufferedInputStream(
+          this.context.network,
+          this.context.crypto,
+          props.sizeHigh(),
+            props.sizeLow(),
+            20,
+          function (read) {}
+        ).thenApply(function (reader) {
+            var size = that.getFileSize(props)
+            var data = convertToByteArray(new Int8Array(size))
+            reader.readIntoArray(data, 0, data.length).thenApply(function (read) {
+                result.complete(data);
+            })
+        }).exceptionally(function (throwable) {
+          result.complete(null);
+        })
+      return result;
     }
   }
 }

--- a/src/mixins/sandbox/index.js
+++ b/src/mixins/sandbox/index.js
@@ -55,7 +55,6 @@ module.exports = {
       },
       verifyJSONFile: function(file, appPath) {
           let that = this;
-          let appNames = this.sandboxedApps.appsInstalled.slice();
           let future = peergos.shared.util.Futures.incomplete();
           this.readJSONFile(file).thenApply(props => {
               let that = this;
@@ -64,10 +63,11 @@ module.exports = {
               } else {
                   let errors = [];
                   let mandatoryFields = ["displayName", "description", "launchable"];
-                  let stringFields = ["displayName", "description", "version", "author", "appIcon", "source"];
+                  let stringFields = ["displayName", "description", "version", "author", "appIcon", "source", "template", "chatId"];
                   let existingCreateMenuItems = ["upload files","upload folder","new folder","new file", "new app"];
                   let validPermissions = ["STORE_APP_DATA", "EDIT_CHOSEN_FILE", "READ_CHOSEN_FOLDER",
                     "EXCHANGE_MESSAGES_WITH_FRIENDS", "USE_MAILBOX", "ACCESS_PROFILE_PHOTO", "CSP_UNSAFE_EVAL"];
+                  let validTemplateValues = ["messaging"];
                   mandatoryFields.forEach(field => {
                       if (props[field] == null) {
                           errors.push("Missing property " + field);
@@ -147,6 +147,17 @@ module.exports = {
                               }
                           });
                       }
+                      if (props.template.length > 0) {
+                          let templateIndex = validTemplateValues.findIndex(v => v === props.template);
+                          if (templateIndex == -1) {
+                              errors.push("Invalid template type: " + props.template);
+                          } else {
+                              let permissionIndex = props.permissions.findIndex(v => v === "EXCHANGE_MESSAGES_WITH_FRIENDS");
+                              if (permissionIndex == -1) {
+                                  errors.push("Template App must have permission: EXCHANGE_MESSAGES_WITH_FRIENDS");
+                              }
+                          }
+                      }
                   }
                     if (errors.length == 0 && appPath != null) {
                       that.validateAppIconImage(props.appIcon, appPath, errors).thenApply(isIconOK => {
@@ -204,11 +215,11 @@ module.exports = {
           if (file == null) {
                 future.complete(null);
           } else {
-              let props = file.getFileProperties();
-              var low = props.sizeLow();
+              let fileProps = file.getFileProperties();
+              var low = fileProps.sizeLow();
               if (low < 0) low = low + Math.pow(2, 32);
-              let size = low + (props.sizeHigh() * Math.pow(2, 32));
-              file.getInputStream(this.context.network, this.context.crypto, props.sizeHigh(), props.sizeLow(), (progress) => {}).thenApply(reader => {
+              let size = low + (fileProps.sizeHigh() * Math.pow(2, 32));
+              file.getInputStream(this.context.network, this.context.crypto, fileProps.sizeHigh(), fileProps.sizeLow(), (progress) => {}).thenApply(reader => {
                   let data = convertToByteArray(new Int8Array(size));
                   return reader.readIntoArray(data, 0, data.length).thenApply(read => {
                       try {
@@ -231,6 +242,12 @@ module.exports = {
                           if (props.appIcon == null) {
                               props.appIcon = '';
                           }
+                          if (props.template == null) {
+                              props.template = '';
+                          }
+                          if (props.chatId == null) {
+                              props.chatId = '';
+                          }
                           if (props.fileExtensions == null) {
                               props.fileExtensions = [];
                           }
@@ -243,7 +260,7 @@ module.exports = {
                           if (props.permissions == null) {
                               props.permissions = [];
                           }
-                          props.name = props.displayName.replaceAll(' ', '').toLowerCase().trim();
+                          props.name = props.name != null ? props.name : props.displayName.replaceAll(' ', '').toLowerCase().trim();
                           future.complete(props);
                       } catch (ex) {
                           console.log(ex);
@@ -267,19 +284,14 @@ module.exports = {
                             future.complete(null);
                         } else {
                             let props = propFileOpt.ref.getFileProperties();
-                            if (!fromRecommendedApps && !props.created.equals(props.modified)) {
-                                console.log('peergos-app.json file has changed! App: ' + appName);
-                                future.complete(null);
-                            } else {
-                                that.readJSONFile(propFileOpt.ref).thenApply(res => {
-                                    if (res == null) {
-                                        console.log('Properties not found! App: ' + appName);
-                                        future.complete(null);
-                                    } else {
-                                        future.complete(res);
-                                    }
-                                });
-                            }
+                            that.readJSONFile(propFileOpt.ref).thenApply(res => {
+                                if (res == null) {
+                                    console.log('Properties not found! App: ' + appName);
+                                    future.complete(null);
+                                } else {
+                                    future.complete(res);
+                                }
+                            });
                         }
                     });
                 } else {

--- a/src/mixins/sandbox/index.js
+++ b/src/mixins/sandbox/index.js
@@ -63,7 +63,7 @@ module.exports = {
               } else {
                   let errors = [];
                   let mandatoryFields = ["displayName", "description", "launchable"];
-                  let stringFields = ["displayName", "description", "version", "author", "appIcon", "source", "template", "chatId"];
+                  let stringFields = ["displayName", "description", "version", "author", "appIcon", "source", "template", "chatId", "templateIconBase64"];
                   let existingCreateMenuItems = ["upload files","upload folder","new folder","new file", "new app"];
                   let validPermissions = ["STORE_APP_DATA", "EDIT_CHOSEN_FILE", "READ_CHOSEN_FOLDER",
                     "EXCHANGE_MESSAGES_WITH_FRIENDS", "USE_MAILBOX", "ACCESS_PROFILE_PHOTO", "CSP_UNSAFE_EVAL"];
@@ -156,6 +156,9 @@ module.exports = {
                               if (permissionIndex == -1) {
                                   errors.push("Template App must have permission: EXCHANGE_MESSAGES_WITH_FRIENDS");
                               }
+                              if (props.appIcon.length == 0) {
+                                  errors.push("Template App must have an AppIcon");
+                              }
                           }
                       }
                   }
@@ -247,6 +250,9 @@ module.exports = {
                           }
                           if (props.chatId == null) {
                               props.chatId = '';
+                          }
+                          if (props.templateIconBase64 == null) {
+                              props.templateIconBase64 = '';
                           }
                           if (props.fileExtensions == null) {
                               props.fileExtensions = [];
@@ -460,7 +466,8 @@ module.exports = {
             let item = {name: props.name, displayName: props.displayName,
                 createFile: createFile, openFile: openFile, openFileFilters: openFileFilters, launchable: props.launchable,
                 folderAction: props.folderAction, appIcon: props.appIcon, contextMenuText: contextMenuText,
-                source: props.source, version: props.version, createFile: createFile, primaryFileExtension: primaryFileExtension};
+                source: props.source, version: props.version, createFile: createFile, primaryFileExtension: primaryFileExtension,
+                templateIconBase64: props.templateIconBase64, chatId: props.chatId, template : props.template};
 
             appsInstalled.push(item);
             props.fileExtensions.forEach(extension => {

--- a/src/views/Launcher.vue
+++ b/src/views/Launcher.vue
@@ -558,16 +558,22 @@ module.exports = {
                 if (app.appIcon.length == 0 ||  (appIndex > -1 && this.appsList[appIndex].thumbnail != null)) {
                     this.loadAppIconsRecursively(apps, index + 1, cb);
                 } else {
-                    let fullPathToAppIcon = "/" + this.context.username + "/.apps/" + app.name + '/assets/' + app.appIcon;
-                    that.findFile(fullPathToAppIcon).thenApply(file => {
-                        if (file != null) {
-                           if (appIndex > -1) {
-                               let appRow = that.appsList[appIndex];
-                               appRow.thumbnail = file.getBase64Thumbnail();
-                           }
-                        }
+                    if (app.templateIconBase64 != null && app.templateIconBase64.length > 0) {
+                        let appRow = that.appsList[appIndex];
+                        appRow.thumbnail = app.templateIconBase64;
                         that.loadAppIconsRecursively(apps, index + 1, cb);
-                    });
+                    } else {
+                        let fullPathToAppIcon = "/" + this.context.username + "/.apps/" + app.name + '/assets/' + app.appIcon;
+                        that.findFile(fullPathToAppIcon).thenApply(file => {
+                            if (file != null) {
+                               if (appIndex > -1) {
+                                   let appRow = that.appsList[appIndex];
+                                   appRow.thumbnail = file.getBase64Thumbnail();
+                               }
+                            }
+                            that.loadAppIconsRecursively(apps, index + 1, cb);
+                        });
+                    }
                 }
             }
         },
@@ -641,8 +647,26 @@ module.exports = {
         },
         deleteApp(app) {
             let that = this;
-            let appDirName = app.name;
             this.showSpinner = true;
+            if (app.template.length > 0) {
+                let that = this;
+                let messenger = new peergos.shared.messaging.Messenger(this.context);
+                messenger.getChat(app.chatId).thenApply(function(controller) {
+                    messenger.deleteChat(controller).thenApply(res => {
+                        that.processAppDelete(app);
+                    }).exceptionally(function(throwable) {
+                        console.log(throwable);
+                        that.showErrorMessage('Error deleting template App: ' + app.name);
+                        that.showSpinner = false;
+                    });
+                });
+            } else {
+                this.processAppDelete(app);
+            }
+        },
+        processAppDelete(app) {
+            let that = this;
+            let appDirName = app.name;
             this.context.getByPath("/" + this.context.username + "/.apps").thenApply(appDirOpt => {
                 if (appDirOpt.ref != null) {
                     appDirOpt.ref.getChild(appDirName, that.context.crypto.hasher, that.context.network).thenApply(appToDeleteOpt => {

--- a/src/views/Launcher.vue
+++ b/src/views/Launcher.vue
@@ -39,7 +39,8 @@
                 v-on:hide-app-installation="closeAppInstallation"
                 :appInstallSuccessFunc="appInstallSuccess"
                 :appPropsFile="appInstallPropsFile"
-                :installFolder="appInstallFolder">
+                :installFolder="appInstallFolder"
+                :templateInstanceAppName="templateInstanceAppName">
             </AppInstall>
             <AppSandbox
                 v-if="showAppSandbox"
@@ -216,6 +217,7 @@ module.exports = {
             pickerShowThumbnail: false,
             filePickerBaseFolder: "",
             htmlAnchor: "",
+            templateInstanceAppName: "",
         }
     },
     props: [],
@@ -471,6 +473,7 @@ module.exports = {
                 if (propsFileOpt.ref != null) {
                     that.appInstallPropsFile = propsFileOpt.ref;
                     that.appInstallFolder = pathStr;
+                    that.templateInstanceAppName = app.name;
                     that.showAppInstallation = true;
                 }
             });

--- a/src/views/NewsFeed.vue
+++ b/src/views/NewsFeed.vue
@@ -44,6 +44,7 @@
                     :installFolder="appInstallFolder"
                     :templateInstanceAppName="templateInstanceAppName"
                     :templateInstanceTitle="templateInstanceTitle"
+                    :templateAppIconBase64="templateAppIconBase64"
                     :templateInstanceChatId="templateInstanceChatId">
                 </AppInstall>
                 <SocialPost
@@ -82,7 +83,6 @@
                     :sandboxAppChatId="sandboxAppChatId"
                     :currentFile="currentFile"
                     :currentPath="currentPath"
-                    :currentProps="appSandboxProps"
                     :htmlAnchor="htmlAnchor"
                 >
                 </AppSandbox>
@@ -332,6 +332,7 @@ module.exports = {
             htmlAnchor: "",
             templateInstanceAppName: "",
             templateInstanceTitle: "",
+            templateAppIconBase64: "",
             templateInstanceChatId: "",
         }
     },
@@ -1066,14 +1067,16 @@ module.exports = {
                         if (entry.appName != appName) {
                             that.templateInstanceAppName = entry.appName;
                             that.templateInstanceChatId = that.extractChatUUIDFromPath(entry.path);
-                            that.getChatAppTitle(that.templateInstanceChatId).thenApply(title => {
-                                that.templateInstanceTitle = title == null ? entry.appName : title;
+                            that.getChatAppTitle(that.templateInstanceChatId).thenApply(metadata => {
+                                that.templateInstanceTitle = metadata.title;
+                                that.templateAppIconBase64 = metadata.iconBase64;
                                 that.showAppInstallation = true;
                             });
                         } else {
                             that.templateInstanceAppName = "";
                             that.templateInstanceChatId = "";
                             that.templateInstanceTitle = "";
+                            that.templateAppIconBase64 = "";
                             that.showAppInstallation = true;
                         }
                     } else {
@@ -1655,8 +1658,10 @@ module.exports = {
             let that = this;
             let future = peergos.shared.util.Futures.incomplete();
             this.messenger.getChat(chatId).thenApply(function(controller) {
-                let title = controller.getTitle();
-                future.complete(title);
+                let obj = {} ;
+                obj.title = controller.getTitle();
+                obj.iconBase64 = controller.getGroupProperty("iconBase64");
+                future.complete(obj);
             }).exceptionally(function(throwable) {
                 console.log('Unable to get title of Chat. Error:' + throwable);
                 future.complete(null);


### PR DESCRIPTION
Motivation:
There is a class of App that isn't currently catered for.
- An App may share the same html/css but require a different name (customisation)
- A number of identical Apps may require a different audience (Chat channel members)

Description:
This change introduces the support for a new type of App called a Template App
A template App has an associated Chat channel

- A template app can be installed from a folder or from the recommended-apps page
- When installed, the user is prompted to enter a name for the App (format: Template - description), ie Forum - Latest News, Album - Wedding 2020.
- The existing update mechanism has been updated to support Template Apps
- A template App can be shared by inviting members as per existing Chat functionality.
- Invitations to join appear on the Newsfeed as per existing functionality.
