### PR TITLE
Limit block cache size to 5GiB

### DIFF
--- a/vendor/priors/gwt.js
+++ b/vendor/priors/gwt.js
@@ -545,6 +545,7 @@ var accountStoreCache;
 var pkiStoreCache;
 var rootKeyCache;
 let SAFARI_CACHE_SIZE = 1024 * 1024 * 700;
+let MAX_CACHE_SIZE = 1024 * 1024 * 1024 * 5;
 
 function bindCacheStore(storeCache) {
     blockStoreCache = storeCache;
@@ -641,7 +642,7 @@ function isSafariTest() {
 }
 function getBrowserStorageQuota() {
     if (navigator.storage && navigator.storage.estimate) {
-        return navigator.storage.estimate().then(quota => quota.quota);
+        return navigator.storage.estimate().then(quota => Math.min(MAX_CACHE_SIZE, quota.quota));
     } else {
 
         let prom = new Promise(function(resolve, reject) { resolve(isSafariTest() ? SAFARI_CACHE_SIZE : 0)});


### PR DESCRIPTION
This fixes an issue with secret links being truncated when a large block cache is present.