### PR TITLE
support capabilityless urls to share between users

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -193,6 +193,10 @@ module.exports = {
             const props = this.getPropsFromUrl();
             if (props != null && props.path!= null)
                that.$store.commit('SET_PATH', props.path.split("/").filter(n => n.length > 0));
+            if (props != null && props.download != null)
+               that.$store.commit('SET_DOWNLOAD', props.download);
+            if (props != null && props.open != null)
+               that.$store.commit('SET_OPEN', props.open);
 
             that.$emit("initApp")
 

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -190,6 +190,10 @@ module.exports = {
 
             that.$store.commit('USER_LOGIN', true);
 
+            const props = this.getPropsFromUrl();
+            if (props != null && props.path!= null)
+               that.$store.commit('SET_PATH', props.path.split("/").filter(n => n.length > 0));
+
             that.$emit("initApp")
 
             // that.$store.commit('CURRENT_MODAL', 'ModalTour');
@@ -208,7 +212,7 @@ module.exports = {
 		},
 		appFromUrl(){
 			const props = this.getPropsFromUrl();
-			const app = props == null ? null : props.app;
+			const app = props == null || props.app == null ? null : props.app;
 			console.log('login app:', app)
 			const driveApps = [null, 'Gallery', 'pdf', 'editor', 'hex', 'markdown', 'markup', 'timeline', 'htmlviewer']
 

--- a/src/mixins/router/index.js
+++ b/src/mixins/router/index.js
@@ -41,8 +41,9 @@ module.exports = {
             let hash = window.location.hash;
             if (hash.length == 0)
                 return null;
+            var rawProps = null;
 	    try {
-                const rawProps = fragmentToProps(hash.substring(1))
+                rawProps = fragmentToProps(hash.substring(1))
 		return this.decryptProps(rawProps);
 	    } catch (e) {
                 try {


### PR DESCRIPTION
This means urls like https://peergos.net/#{"path":"/username/some/path"} will work for for any user and open the dir in the drive

Fixes https://github.com/Peergos/Peergos/issues/1260

This will also open a file with a url like:
https://peergos.net/#{"path":"/q/red","filename":"robin.jpg","app":"Gallery","open":true,"args":{}}