### PR TITLE
add drive dropdown to FolderPicker and FilePicker

### DIFF
--- a/src/components/modal/ModalProfile.vue
+++ b/src/components/modal/ModalProfile.vue
@@ -17,7 +17,8 @@
                 v-if="showFolderPicker"
                 :baseFolder="folderPickerBaseFolder" :selectedFolder_func="selectedFoldersFromPicker"
                 :multipleFolderSelection="multipleFolderSelection"
-                :initiallySelectedPaths="initiallySelectedPaths">
+                :initiallySelectedPaths="initiallySelectedPaths"
+                :noDriveSelection="true">
             </FolderPicker>
             <Share
 			v-if="showShare"

--- a/src/components/sandbox/AppSandbox.vue
+++ b/src/components/sandbox/AppSandbox.vue
@@ -36,6 +36,7 @@
             :pickerFilters="pickerFilters"
             :pickerShowThumbnail="pickerShowThumbnail"
             :selectedFile_func="selectedFileFromPicker"
+            :noDriveSelection="noDriveSelection"
         />
         <FolderPicker
             v-if="showFolderPicker"
@@ -270,6 +271,7 @@ module.exports = {
             app_prompt_consumer_func: () => {},
             app_prompt_action: 'ok',
             appIconBase64Image: "",
+            noDriveSelection: true,
         }
     },
     computed: {
@@ -1053,6 +1055,7 @@ module.exports = {
                 let currentPathExtract = this.getPath;
                 let currentPathExtractWithoutSlash = currentPathExtract.substring(0, currentPathExtract.length -1);
                 this.filePickerBaseFolder =  baseCurrentFolder ? currentPathExtractWithoutSlash : "/" + this.context.username;
+                this.noDriveSelection = baseCurrentFolder;
                 let fileExtensionFilter = params.get('extension');
                 this.pickerFileExtension = fileExtensionFilter == null ? "" : fileExtensionFilter;
                 let fileMediaFilter = params.get('media');


### PR DESCRIPTION
add a drive dropdown to FolderPicker and FilePicker
This is used when user is prompted to select a folder or file
Also used when installing an app
Previously a user could not choose a file or folder in a friend's drive

FilePicker
<img width="295" alt="file-picker" src="https://github.com/user-attachments/assets/d7d6d0dc-ce82-436e-9e4d-29e04524c1d8" />

FolderPicker
<img width="436" alt="folder-picker" src="https://github.com/user-attachments/assets/ba81705b-9b69-4e8b-be1c-dc74ce50465e" />


