### PR TITLE
improve new file picker component

### DIFF
--- a/src/mixins/sandbox/index.js
+++ b/src/mixins/sandbox/index.js
@@ -120,6 +120,26 @@ module.exports = {
                       if (props.source.length > 256) {
                           errors.push("Invalid Source property. Length must not exceed 256 characters");
                       }
+                      if (!(props.newFileExtensions.constructor === Array)) {
+                          errors.push("Invalid newFileExtensions property. Must be an array. Can be empty []");
+                      } else {
+                          let newFileExtensions = [];
+                          props.newFileExtensions.forEach(newFileExtension => {
+                              var ok = true;
+                              if (newFileExtension.extension == null || !that.isString(newFileExtension.extension)) {
+                                  errors.push("Invalid newFileExtensions property. Expecting extension property");
+                                  ok = false;
+                              }
+                              if (newFileExtension.name == null || !that.isString(newFileExtension.name)) {
+                                  errors.push("Invalid newFileExtensions property. Expecting name property");
+                                  ok = false;
+                              }
+                              if (ok) {
+                                  newFileExtensions.push({extension: newFileExtension.extension.toLowerCase(), name: newFileExtension.name});
+                              }
+                          });
+                          props.newFileExtensions = newFileExtensions;
+                      }
                       if (!(props.fileExtensions.constructor === Array)) {
                           errors.push("Invalid fileExtensions property. Must be an array. Can be empty []");
                       } else {
@@ -253,6 +273,9 @@ module.exports = {
                           }
                           if (props.templateIconBase64 == null) {
                               props.templateIconBase64 = '';
+                          }
+                          if (props.newFileExtensions == null) {
+                              props.newFileExtensions = [];
                           }
                           if (props.fileExtensions == null) {
                               props.fileExtensions = [];
@@ -467,7 +490,7 @@ module.exports = {
                 createFile: createFile, openFile: openFile, openFileFilters: openFileFilters, launchable: props.launchable,
                 folderAction: props.folderAction, appIcon: props.appIcon, contextMenuText: contextMenuText,
                 source: props.source, version: props.version, createFile: createFile, primaryFileExtension: primaryFileExtension,
-                templateIconBase64: props.templateIconBase64, chatId: props.chatId, template : props.template};
+                templateIconBase64: props.templateIconBase64, chatId: props.chatId, template : props.template, newFileExtensions: props.newFileExtensions};
 
             appsInstalled.push(item);
             props.fileExtensions.forEach(extension => {

--- a/src/views/Launcher.vue
+++ b/src/views/Launcher.vue
@@ -17,6 +17,7 @@
                 v-if="showNewFilePicker"
                 @hide-prompt="closeNewFilePicker()"
                 :pickerFileExtension="pickerFileExtension"
+                :pickerMultipleFileExtensions="pickerMultipleFileExtensions"
                 :consumer_func="prompt_consumer_func"
             />
             <FilePicker
@@ -213,6 +214,7 @@ module.exports = {
             showNewFilePicker: false,
             prompt_consumer_func: () => { },
             pickerFileExtension: '',
+            pickerMultipleFileExtensions: [],
             showReplace: false,
             replace_message: "",
             replace_body: "",
@@ -227,7 +229,6 @@ module.exports = {
             initiallySelectedPaths: [],
             showFilePicker: false,
             selectedFileFromPicker: null,
-            pickerFileExtension: "",
             pickerFilterMedia: false,
             pickerFilters: null,
             pickerShowThumbnail: false,
@@ -242,6 +243,7 @@ module.exports = {
             existingAdmins: [],
             isTemplateApp: false,
             currentApp: null,
+            replace_showApplyAll: false,
         }
     },
     props: [],
@@ -372,6 +374,7 @@ module.exports = {
                     });
                 };
                 this.pickerFileExtension = app.primaryFileExtension;
+                this.pickerMultipleFileExtensions = app.newFileExtensions;
                 this.showNewFilePicker = true;
             } else if (app.openFile) {
                 this.filePickerBaseFolder = "/" + this.context.username;

--- a/src/views/NewsFeed.vue
+++ b/src/views/NewsFeed.vue
@@ -1342,7 +1342,8 @@ module.exports = {
                         info = this.translate("NEWSFEED.INVITED.APP") + " " + app[0].displayName;
                     } else {
                         let actualAppName = this.extractChatAppName(appName);
-                        info = this.translate("NEWSFEED.INVITED.APP") + " " + actualAppName;
+                        let formattedAppName = actualAppName.substring(0,1).toUpperCase() + actualAppName.substring(1);
+                        info = this.translate("NEWSFEED.INVITED.APP") + " " + formattedAppName;
                     }
                     displayFilename = false;
                 } else {


### PR DESCRIPTION
- New file picker UI now supports a dropdown for creating files of different types (ie office suite app supports word processor, spreadsheet, presentation file)
- add newFileExtensions app property to support the above. ie:
"newFileExtensions": [
		{"extension": "docx", "name": "Microsoft Word"}, 
		{"extension": "odt", "name": "ODF Text Document"},
		{"extension": "xlsx", "name": "Microsoft Excel"},
		{"extension": "ods", "name": "ODF Spreadsheet"},
		{"extension": "pptx", "name": "Microsoft PowerPoint"},
		{"extension": "odp", "name": "ODF Presentation"},
		{"extension": "odg", "name": "ODF Drawing"}
	],
- workaround to app install process to handle case where app does not install correctly on first attempt
- small presentation bugfix to NewsFeed

