### PR TITLE
Fix calendar month view leaving a day stuck highlighted

### DIFF
--- a/assets/apps/calendar/tui-calendar.js
+++ b/assets/apps/calendar/tui-calendar.js
@@ -13749,6 +13749,10 @@ MonthCreationGuide.prototype._createGuideElement = function(dragStartEvent) {
         top: 0
     };
 
+    if (this.guide) {
+        this.guide.destroy();
+    }
+
     this.guide = new MonthGuide(options, this.monthCreation.monthView);
     this.guide.start(dragStartEvent);
 };


### PR DESCRIPTION
## Bug

In the calendar app's month view, clicking a day (opening the event
creation popup) and then clicking a *different* day before closing
or saving the first one leaves the first day's cell permanently
highlighted. The highlight only clears once the month grid fully
re-renders (e.g. navigating to another month and back). The stuck
cell is also unresponsive to further clicks in the meantime.

Clicking the popup's ✕ close button (instead of clicking straight to
another day) does *not* trigger the bug.

## Root cause

`MonthCreationGuide` (in the vendored TOAST UI Calendar bundle,
`assets/apps/calendar/tui-calendar.js`) creates a `MonthGuide`
instance to render the day-cell highlight, stored on
`this.guide`. Its `_createGuideElement` handler runs on every day
click, but it overwrites `this.guide` with a brand-new `MonthGuide`
without ever calling `.destroy()`/`.clear()` on the previous one.
The old highlight's DOM nodes become orphaned — nothing still
references them to remove them — so they stay in the grid
indefinitely.

## Fix

Destroy the existing guide before creating a new one, so at most one
highlight instance (and its DOM) ever exists at a time.

## Testing

Manually verified: click day A (popup opens, day A highlighted) →
click day B without closing the popup → day A's highlight clears
immediately and day B is highlighted and editable; no regression to
the existing "click ✕ to close" flow.

Before:
<img width="1553" height="818" alt="image" src="https://github.com/user-attachments/assets/192c328c-3e8c-446b-912a-c53c6cae22d1" />

After:
<img width="1553" height="704" alt="image" src="https://github.com/user-attachments/assets/ec1c76f6-b0ba-41f5-945a-bd12268a37de" />
