### PR TITLE
Fix empty folders being silently dropped when uploading a folder

### DIFF
--- a/src/components/drive/DriveHeader.vue
+++ b/src/components/drive/DriveHeader.vue
@@ -139,6 +139,7 @@ module.exports = {
                                 if (e && e.name !== 'AbortError') console.log(e);
                             });
                         } else {
+                            this.$toast.info(this.translate("DRIVE.UPLOAD.FOLDER.EMPTY.WARNING"), {id: 'upload-folder-limitation'});
                             document.getElementById('uploadDirectoriesInput').click();
                         }
 		},

--- a/src/components/drive/DriveHeader.vue
+++ b/src/components/drive/DriveHeader.vue
@@ -127,9 +127,44 @@ module.exports = {
                         if (typeof Android !== 'undefined') {
                             Android.notifyDirectoryRequest();
                             document.getElementById('uploadFileInput').click();
+                        } else if (typeof window.showDirectoryPicker === 'function') {
+                            // Unlike <input webkitdirectory>, this can see empty folders too.
+                            let that = this;
+                            window.showDirectoryPicker().then(function(dirHandle) {
+                                let files = [], directories = [];
+                                that.walkDirectoryHandle(dirHandle, '/' + dirHandle.name, files, directories).then(function() {
+                                    that.$emit('filesToUpload', {files: files, directories: directories});
+                                });
+                            }).catch(function(e) {
+                                if (e && e.name !== 'AbortError') console.log(e);
+                            });
                         } else {
                             document.getElementById('uploadDirectoriesInput').click();
                         }
+		},
+
+		// Walks a FileSystemDirectoryHandle, collecting files (tagged with their folder's
+		// path) and every directory path seen, including empty ones.
+		walkDirectoryHandle(dirHandle, path, files, directories) {
+			let that = this;
+			directories.push(path);
+			let iterator = dirHandle.entries();
+			function readNext() {
+				return iterator.next().then(function(result) {
+					if (result.done) return true;
+					let [name, handle] = result.value;
+					if (handle.kind !== 'file') {
+						return that.walkDirectoryHandle(handle, path + '/' + name, files, directories).then(readNext);
+					}
+					if (name == '.DS_Store') return readNext();
+					return handle.getFile().then(function(file) {
+						file.directory = path;
+						files.push(file);
+						return readNext();
+					});
+				});
+			}
+			return readNext();
 		},
 	},
 }

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -51,6 +51,7 @@ module.exports = {
     "DRIVE.DROP": "Dateien hier ablegen",
     "DRIVE.UPLOAD.FILES": "Dateien hochladen",
     "DRIVE.UPLOAD.FOLDER": "Ordner hochladen",
+    "DRIVE.UPLOAD.FOLDER.EMPTY.WARNING": "Dieser Browser kann leere Unterordner auf diese Weise nicht hochladen - bitte verwenden Sie stattdessen Drag & Drop, um sie einzuschließen.",
     "DRIVE.NEW.FOLDER": "Neuer Ordner",
     "DRIVE.NEW.FILE": "Neue Datei",
     "DRIVE.NEW.APP": "Neue App",

--- a/src/i18n/en-GB.js
+++ b/src/i18n/en-GB.js
@@ -61,6 +61,7 @@ module.exports = {
     "DRIVE.DROP":"Drop files here",
     "DRIVE.UPLOAD.FILES":"Upload files",
     "DRIVE.UPLOAD.FOLDER":"Upload folder",
+    "DRIVE.UPLOAD.FOLDER.EMPTY.WARNING":"This browser cannot upload empty subfolders in this way - please use drag and drop to include them instead.",
     "DRIVE.NEW.FOLDER":"New folder",
     "DRIVE.NEW.FILE":"New file",
     "DRIVE.NEW.APP":"New App",

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -49,6 +49,7 @@ module.exports = {
     "DRIVE.DROP": "Suelta archivos aquí",
     "DRIVE.UPLOAD.FILES": "Subir archivos",
     "DRIVE.UPLOAD.FOLDER": "Subir carpeta",
+    "DRIVE.UPLOAD.FOLDER.EMPTY.WARNING": "Este navegador no puede subir subcarpetas vacías de esta forma; utiliza arrastrar y soltar para incluirlas.",
     "DRIVE.NEW.FOLDER": "Nueva carpeta",
     "DRIVE.NEW.FILE": "Nuevo archivo",
     "DRIVE.NEW.APP": "Nueva aplicación",

--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -49,6 +49,7 @@ module.exports = {
     "DRIVE.DROP": "Déposez des fichiers ici",
     "DRIVE.UPLOAD.FILES": "Téléverser des fichiers",
     "DRIVE.UPLOAD.FOLDER": "Téléverser un dossier",
+    "DRIVE.UPLOAD.FOLDER.EMPTY.WARNING": "Ce navigateur ne peut pas téléverser les sous-dossiers vides de cette façon - veuillez utiliser le glisser-déposer pour les inclure.",
     "DRIVE.NEW.FOLDER": "Nouveau dossier",
     "DRIVE.NEW.FILE": "Nouveau fichier",
     "DRIVE.NEW.APP": "Nouvelle application",

--- a/src/i18n/it.js
+++ b/src/i18n/it.js
@@ -49,6 +49,7 @@ module.exports = {
     "DRIVE.DROP":"Trascina i file qui",
     "DRIVE.UPLOAD.FILES":"Carica file",
     "DRIVE.UPLOAD.FOLDER":"Carica cartella",
+    "DRIVE.UPLOAD.FOLDER.EMPTY.WARNING":"Questo browser non può caricare le sottocartelle vuote in questo modo: utilizza il trascinamento (drag and drop) per includerle.",
     "DRIVE.NEW.FOLDER":"Nuova cartella",
     "DRIVE.NEW.FILE":"Nuovo file",
     "DRIVE.NEW.APP":"Nuova app",

--- a/src/i18n/ko.js
+++ b/src/i18n/ko.js
@@ -51,6 +51,7 @@ module.exports = {
     "DRIVE.DROP":"파일을 여기에 끌어다 놓으세요",
     "DRIVE.UPLOAD.FILES":"파일 업로드",
     "DRIVE.UPLOAD.FOLDER":"폴더 업로드",
+    "DRIVE.UPLOAD.FOLDER.EMPTY.WARNING":"이 브라우저에서는 이 방식으로 빈 하위 폴더를 업로드할 수 없습니다. 대신 끌어다 놓기(드래그 앤 드롭)를 사용해 포함하세요.",
     "DRIVE.NEW.FOLDER":"새 폴더",
     "DRIVE.NEW.FILE":"새 파일",
     "DRIVE.NEW.APP":"새 앱",

--- a/src/i18n/nl-BE.js
+++ b/src/i18n/nl-BE.js
@@ -61,6 +61,7 @@ module.exports = {
     "DRIVE.DROP":"Sleep je bestanden hier",
     "DRIVE.UPLOAD.FILES":"Beestanden uploaden",
     "DRIVE.UPLOAD.FOLDER":"Folders uploaden",
+    "DRIVE.UPLOAD.FOLDER.EMPTY.WARNING":"Deze browser kan lege submappen op deze manier niet uploaden - gebruik in plaats daarvan slepen en neerzetten om ze toe te voegen.",
     "DRIVE.NEW.FOLDER":"Nieuwe folder",
     "DRIVE.NEW.FILE":"Nieuw bestand",
     "DRIVE.NEW.APP":"Nieuwe App",

--- a/src/i18n/pl.js
+++ b/src/i18n/pl.js
@@ -49,6 +49,7 @@ module.exports = {
     "DRIVE.DROP":"Upuść pliki tutaj",
     "DRIVE.UPLOAD.FILES":"Prześlij pliki",
     "DRIVE.UPLOAD.FOLDER":"Prześlij folder",
+    "DRIVE.UPLOAD.FOLDER.EMPTY.WARNING":"Ta przeglądarka nie może w ten sposób przesłać pustych podfolderów - użyj metody przeciągnij i upuść, aby je uwzględnić.",
     "DRIVE.NEW.FOLDER":"Nowy folder",
     "DRIVE.NEW.FILE":"Nowy plik",
     "DRIVE.NEW.APP":"Nowa aplikacja",

--- a/src/i18n/zh-CN.js
+++ b/src/i18n/zh-CN.js
@@ -46,6 +46,7 @@ module.exports = {
     "DRIVE.DROP":"将文件拖放到此处",
     "DRIVE.UPLOAD.FILES":"上传文件",
     "DRIVE.UPLOAD.FOLDER":"上传文件夹",
+    "DRIVE.UPLOAD.FOLDER.EMPTY.WARNING":"此浏览器无法以这种方式上传空的子文件夹 - 请改用拖放操作以包含它们。",
     "DRIVE.NEW.FOLDER":"新文件夹",
     "DRIVE.NEW.FILE":"新文件",
     "DRIVE.NEW.APP":"新应用",

--- a/src/views/Drive.vue
+++ b/src/views/Drive.vue
@@ -35,6 +35,7 @@
       @newApp="createNewApp()"
       @search="openSearch(false)"
       @paste="pasteToFolder($event)"
+      @filesToUpload="processFileUpload($event.files, undefined, $event.directories)"
     />
 
     <AppPrompt
@@ -1986,14 +1987,17 @@ module.exports = {
 				}
 			}
 			let allFiles = [];
+			let allDirectories = [];
 			if (allItems.length > 0) {
-				this.getEntries(allItems, 0, this, allFiles);
+				this.getEntries(allItems, 0, this, allFiles, allDirectories);
 			}
 		},
-		getEntries(items, itemIndex, that, allFiles) {
+		getEntries(items, itemIndex, that, allFiles, allDirectories) {
 			if (itemIndex < items.length) {
 				let item = items[itemIndex];
 				if (item.isDirectory) {
+					// record the directory even if it turns out to have no files, so it still gets created
+					allDirectories.push(item.fullPath);
 					let reader = item.createReader();
 					let doBatch = function () {
 						reader.readEntries(function (entries) {
@@ -2003,7 +2007,7 @@ module.exports = {
 								}
 								doBatch();
 							} else {
-								that.getEntries(items, ++itemIndex, that, allFiles);
+								that.getEntries(items, ++itemIndex, that, allFiles, allDirectories);
 							}
 						});
 					};
@@ -2014,11 +2018,11 @@ module.exports = {
                             fileEntry.directory = that.extractDirectory(item);
                             allFiles.push(fileEntry);
                         }
-                        that.getEntries(items, ++itemIndex, that, allFiles);
+                        that.getEntries(items, ++itemIndex, that, allFiles, allDirectories);
                     });
 				}
 			} else {
-				this.processFileUpload(allFiles);
+				this.processFileUpload(allFiles, undefined, allDirectories);
 			}
 		},
         extractDirectory(file) {
@@ -2095,8 +2099,9 @@ module.exports = {
             (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
           );
         },
-	processFileUpload(files, retrying) {
+	processFileUpload(files, retrying, extraDirectories) {
             let that = this;
+            extraDirectories = extraDirectories || [];
             if (this.isSecretLink && !this.currentDir.isWritable()) {
                 return;
             }
@@ -2105,10 +2110,10 @@ module.exports = {
                     this.updateQuota(quotaBytes => {
                         if (quotaBytes != null) {
                             that.updateUsage(usageBytes => {
-                                that.processFileUpload(files, true);
+                                that.processFileUpload(files, true, extraDirectories);
                             });
                         } else {
-                            that.processFileUpload(files, true);
+                            that.processFileUpload(files, true, extraDirectories);
                         }
                     });
                 } else {
@@ -2160,6 +2165,16 @@ module.exports = {
                             title: title,
                             lastTitle: title,
                             lastSubtitle: '',
+                        }
+                        // pre-seed folders with no files of their own (e.g. empty dirs) so they still get created
+                        for (var d = 0; d < extraDirectories.length; d++) {
+                            let dirPath = extraDirectories[d];
+                            let fullDirPath = dirPath.length == 0 ? uploadParams.directoryPath
+                                : uploadParams.directoryPath.substring(0, uploadParams.directoryPath.length - 1) + dirPath;
+                            if (uploadParams.uploadPaths.indexOf(fullDirPath) == -1) {
+                                uploadParams.uploadPaths.push(fullDirPath);
+                                uploadParams.fileUploadProperties.push([]);
+                            }
                         }
                         uploadParams.progressInterval = setInterval(() => {
                             const stats = helpers.formatTransferStats(uploadParams.progress.done, uploadParams.progress.max, uploadParams.progress.startTime);
@@ -2296,7 +2311,7 @@ module.exports = {
         reduceAllUploads: function(index, files, future, uploadParams, previousDirectoryHolder) {
             let that = this;
             if (index == files.length) {
-                if (uploadParams.progress.total == 0) {
+                if (uploadParams.progress.total == 0 && uploadParams.uploadPaths.length == 0) {
                     that.addUploadProgressMessage(uploadParams, that.translate("DRIVE.UPLOAD.EMPTY"), '', '', '', true);
                 }
                 future.complete(true);


### PR DESCRIPTION
Hello Peergos team,
During usage of Desktop Peergos app I found the following issue. Since I'm not a Vue.js developer I used Claude Code to fix and document it. I tested it in Firefox and Chromium browsers to see the expected behaviors after the fix.

## Bug

Uploading a folder tree that contains an empty subfolder (or a
subfolder whose only content is a filtered-out `.DS_Store`) silently
drops that subfolder - it never appears at the destination, with no
error or warning. Reported via drive folder upload testing: a folder
with 0 direct files and 8 empty sub-folders vanished entirely.

## Root cause

Folder creation is inferred entirely from the paths of uploaded
files (`processFileUpload` → `uploadFileJS`, `src/views/Drive.vue`).
A folder only gets added to the list of folders to create on the
server if at least one file lives in it somewhere. A folder with no
files anywhere in its own subtree contributes nothing, so it's never
created - this affects both the drag-and-drop upload path and the
"Upload folder" menu button.

For the "Upload folder" button specifically, this is a hard
platform limitation, not a logic bug: it uses
`<input type="file" webkitdirectory>`, and that API's `FileList`
**only ever contains files** - the browser gives JavaScript no
information about empty directories at all, so there's nothing in
the existing code path to fix.

## Fix (commit 1)

- **Drag-and-drop**: `getEntries()` already walks real directory
  entries via `webkitGetAsEntry()`/`readEntries()`, so it now records
  every directory path it visits, not just ones containing files.
  `processFileUpload()` takes a new `extraDirectories` param and
  pre-seeds the upload's folder list with any of those paths that no
  file already covers, so they still get created with zero files.
- **"Upload folder" button**: rebuilt to prefer the File System
  Access API (`showDirectoryPicker()`) where available, which *can*
  walk real directory handles including empty ones. Falls back to
  the original `<input webkitdirectory>` behavior where the API
  isn't supported.

### Platform/browser coverage

| Environment | Engine | Result |
|---|---|---|
| Chrome / Edge | Chromium | Both button and drag-and-drop fixed |
| Firefox | Gecko | Drag-and-drop fixed; button falls back (see commit 2) |
| Safari | WebKit | Same as Firefox |
| Windows desktop app | WebView2 (Chromium) | Should work like Chrome |
| macOS desktop app | WKWebView (WebKit) | Same as Firefox/Safari - confirmed via the native Swift delegate code |
| Linux desktop app | none - runs as a plain server, opens in the user's own browser | Depends on browser, as above |
| Android app | N/A | Unaffected - has its own native directory-picking path (`Android.notifyDirectoryRequest()`) that this change doesn't touch |

## User-facing notice (commit 2)

Where the fallback is used, silently reproducing the old limitation
felt worse than saying nothing, so an info toast now explains it and
points at drag-and-drop as the workaround. Translated into all
supported GUI languages (machine/model-quality translations for the
8 non-English locales - worth a native-speaker pass before/after
merge, especially Korean and Chinese).

## Testing

Manually verified by the reporter:
- Drag-and-drop with an empty subfolder: **works**
- "Upload folder" button on Firefox: falls back correctly, toast
  appears
- Chromium-based desktop apps: not yet tested live, reasoned about
  from the wrapper source (WebView2 is Chromium) but not confirmed
  hands-on

Not yet tested: Safari, macOS desktop app, Android (expected
unaffected), very large/deep folder trees.