### PR TITLE
Fix the tray icon not registering

### DIFF
--- a/packager/electron/main.js
+++ b/packager/electron/main.js
@@ -377,7 +377,15 @@ function wireSession() {
 app.setName('Peergos');
 app.commandLine.appendSwitch('class', APP_ID);
 
-app.on('before-quit', () => { app.quitting = true; });
+app.on('before-quit', () => {
+    app.quitting = true;
+    // Taken down rather than left to go with the process: handed no removal, a
+    // panel can keep the dead icon and start us again when it is clicked.
+    if (tray !== null) {
+        tray.destroy();
+        tray = null;
+    }
+});
 
 // Quitting has to exit 0: the Java server watches this process and shuts itself
 // down when it ends. Hiding the window must never reach here.

--- a/packager/flatpak/org.peergos.Peergos.yaml
+++ b/packager/flatpak/org.peergos.Peergos.yaml
@@ -28,10 +28,13 @@ finish-args:
   - --filesystem=home
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.secrets
-  # register the tray icon. Owning org.kde.StatusNotifierItem-$PID-$ITEM_ID is
-  # not needed, and is unreliable in a sandbox: we register under our unique
-  # bus name instead.
+  # register the tray icon, and own the name it is registered under: chromium
+  # takes org.freedesktop.StatusNotifierItem-$PID-$ITEM_ID and, refused it,
+  # falls back to a unique name the watcher does not pick up - leaving no icon,
+  # and a window that hides into a tray which cannot show it. Wider than that
+  # one name because flatpak matches whole segments, and the pid is not known.
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --own-name=org.freedesktop.*
 
   # all, not dri and usb: a security key is spoken to over /dev/hidraw, which no
   # narrower permission reaches


### PR DESCRIPTION
Chromium registers its status icon under
`org.freedesktop.StatusNotifierItem-$PID-$ITEM_ID`. The manifest never granted
`--own-name`, so the bus proxy refused that name and Chromium fell back to its
unique connection name, which the watcher does not pick up. The icon then never
appeared - and because `refreshTrayAvailable` only asks whether a tray host
exists, the window still hid into a tray that could not show it, leaving no way
back to the app.

Granting the name fixes it. It is wider than the single name needed because
flatpak matches whole dot-segments, and the pid is not known in advance.

Also destroy the tray on `before-quit` rather than letting it go with the
process, so the panel is handed a removal instead of inferring one: left to
notice by itself, a panel can keep the dead icon and start the app again when it
is clicked.

Tested on KDE Plasma (Wayland): the icon registers, and is removed on quit with
no processes left behind.