### PR TITLE
Show a sync failure that no folder owns, and report a paused sync as paused

### DIFF
--- a/src/views/Sync.vue
+++ b/src/views/Sync.vue
@@ -359,23 +359,25 @@ module.exports = {
 			return res;
 		},
 		// the server aggregates, but fall back to pair states if it is silent
-		/** The failure no folder owns. Hidden only when a folder is already showing the
-		 *  same text, so the cause is always stated somewhere, and never twice. */
+		/** The failure no folder owns. Hidden as soon as any folder is reporting one of its
+		 *  own, so the cause is always stated somewhere, and never twice. */
 		globalError() {
 			// offline, a failure is the missing connection restated in java's words
 			if (this.offline || ! this.error || this.wasStopped(this.error))
 				return null;
-			let text = this.cleanError(this.error);
+			// a folder reporting a failure of its own says it on its own card, so the
+			// banner stays out of the way rather than repeating it
 			for (let pair of this.syncPairs) {
-				if (pair.error && ! this.wasStopped(pair.error) && this.cleanError(pair.error) === text)
+				if (pair.error && ! this.wasStopped(pair.error))
 					return null;
 			}
-			return text;
+			return this.cleanError(this.error);
 		},
 		tone() {
 			// an error outlives a pause, as SyncStatus.aggregate decides on the server: it is
-			// something the user has to act on, and the pause is already shown by the button
-			if (this.counts.ERROR > 0)
+			// something the user has to act on, and the pause is already shown by the button.
+			// It outranks the queued states below whether or not a folder owns it.
+			if (this.counts.ERROR > 0 || this.globalError != null)
 				return "error";
 			if (this.paused)
 				return "paused";
@@ -611,7 +613,13 @@ module.exports = {
 					that.statusAtReconnect = null;
 				}
 				that.status = result.msg;
-				that.error = result.error;
+				// a pass that could not run reports itself through the state and the message,
+				// with no error of its own: on android that is a pass held back on mobile data.
+				// The trailing timestamp belongs to a status line rather than to a failure.
+				that.error = result.error != null ? result.error
+					: (result.state === "ERROR"
+						? String(result.msg || "").replace(/ at \d{4}-\d\d-\d\d \d\d:\d\d(:\d\d)?$/, "")
+						: null);
 				that.globalState = result.state != null ? result.state : "NONE";
 				let wasPaused = that.paused;
 				// polling stops while the window is hidden, so a stale reading means the resume

--- a/src/views/Sync.vue
+++ b/src/views/Sync.vue
@@ -374,13 +374,14 @@ module.exports = {
 			return this.cleanError(this.error);
 		},
 		tone() {
-			// an error outlives a pause, as SyncStatus.aggregate decides on the server: it is
-			// something the user has to act on, and the pause is already shown by the button.
-			// It outranks the queued states below whether or not a folder owns it.
-			if (this.counts.ERROR > 0 || this.globalError != null)
-				return "error";
+			// nothing runs while the user has it paused, so that is what the view reports
+			// first: a failure underneath it is still shown on the folder it belongs to
 			if (this.paused)
 				return "paused";
+			// a failure needs the user whether a folder owns it or not, so it outranks
+			// the queued states below, which would show it as work in progress
+			if (this.counts.ERROR > 0 || this.globalError != null)
+				return "error";
 			// nothing was checked against the server, so this is not a settled state
 			if (this.offline || this.awaitingPass)
 				return "pending";
@@ -498,10 +499,10 @@ module.exports = {
 			Vue.set(this.expanded, key, ! this.expanded[key]);
 		},
 		stateOf(pair) {
-			if (pair.error && ! this.wasStopped(pair.error))
-				return "ERROR";
 			if (this.paused)
 				return "PAUSED";
+			if (pair.error && ! this.wasStopped(pair.error))
+				return "ERROR";
 			// offline: this folder was not checked against the Drive, so it is queued,
 			// not settled. The cause is the device, so the banner names it once
 			if (this.offline || this.awaitingPass)


### PR DESCRIPTION
### A failure with no folder to attach it to was never shown

`getSyncState` reads `result.error`, but a pass that could not run reports itself through `state` and `msg` with no error field — on Android, a pass held back on mobile data. `result.msg` was stored in `this.status`, which nothing renders, and `tone()` consulted `globalState` only after the pending and busy branches, so the banner read "Syncing 1 folder" while the server was saying:

```
state = ERROR
msg   = "Not syncing on mobile data. Connect to Wi-Fi, or allow this folder on mobile data."
```

Such a status now becomes the global error. The trailing ` at <timestamp>` is stripped, since it belongs to a status line rather than to a failure — with the seconds optional, because `LocalTime.toString()` omits them on a whole minute.

### `globalError()` no longer compares text

It hid itself only when a folder was showing the *same* string, which breaks as soon as the two sources word it differently. It now steps aside as soon as any folder is reporting a failure of its own, so the cause is stated exactly once, on the card it belongs to.

### Pause outranks everything

In the banner and on each folder, a paused sync reports as paused; the failure stays visible under the card. This matches the change to `SyncStatus.aggregate` in Peergos/Peergos#PR1, so the tray icon and the view can no longer disagree.

Tested on Android and desktop: the failure matrix (no owner / owned / none / stopped pass / offline), pause and resume against a folder in error, and the built bundle booting clean at desktop width.